### PR TITLE
Parameterize test to separate out test on each page, and give each test auto-generated name

### DIFF
--- a/st_smoke_test.py
+++ b/st_smoke_test.py
@@ -1,23 +1,44 @@
 import os
-import glob
+
+from pathlib import Path
+
 import unittest
+
 from streamlit.testing.v1 import AppTest
 
 APP_PATH = os.getenv("APP_PATH", default="streamlit_app.py")
-SKIP_SMOKE = os.getenv("SKIP_SMOKE", 'False').lower() in ('true', '1', 't')
+SKIP_SMOKE = os.getenv("SKIP_SMOKE", "False").lower() in ("true", "1", "t")
+
+
+def get_file_paths() -> list[str]:
+    page_folder = Path(APP_PATH).parent / "pages"
+    if not page_folder.exists():
+        return []
+    page_files = page_folder.glob("*.py")
+    file_paths = [str(file.absolute().resolve()) for file in page_files]
+    return file_paths
+
+
+def pytest_generate_tests(metafunc):
+    """
+    Generate a file path for each page in the pages folder, which will
+    automatically be used if a test function has a file_path argument
+
+    The automatically-generated test will only have the individual file name
+    """
+    if "file_path" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "file_path", get_file_paths(), ids=lambda x: x.split("/")[-1]
+        )
+
 
 @unittest.skipIf(SKIP_SMOKE, "smoke test is disabled by config")
 def test_smoke_main():
-    at = AppTest.from_file(APP_PATH, default_timeout = 100).run()
+    at = AppTest.from_file(APP_PATH, default_timeout=100).run()
     assert not at.exception
 
+
 @unittest.skipIf(SKIP_SMOKE, "smoke test is disabled by config")
-def test_smoke_pages():
-    pages_pattern = os.path.join(os.path.dirname(APP_PATH), "pages/*.py")
-    page_files = glob.glob(pages_pattern)
-    if not page_files:
-        raise unittest.SkipTest("No pages found")
-    for file in page_files:
-        file_path  = os.path.abspath(file)
-        at = AppTest.from_file(file_path, default_timeout = 100).run()
-        assert not at.exception
+def test_smoke_pages(file_path):
+    at = AppTest.from_file(file_path, default_timeout=100).run()
+    assert not at.exception

--- a/st_smoke_test.py
+++ b/st_smoke_test.py
@@ -1,8 +1,6 @@
 import os
-
-from pathlib import Path
-
 import unittest
+from pathlib import Path
 
 from streamlit.testing.v1 import AppTest
 
@@ -13,10 +11,10 @@ SKIP_SMOKE = os.getenv("SKIP_SMOKE", "False").lower() in ("true", "1", "t")
 def get_file_paths() -> list[str]:
     page_folder = Path(APP_PATH).parent / "pages"
     if not page_folder.exists():
-        return []
+        return [APP_PATH]
     page_files = page_folder.glob("*.py")
     file_paths = [str(file.absolute().resolve()) for file in page_files]
-    return file_paths
+    return [APP_PATH] + file_paths
 
 
 def pytest_generate_tests(metafunc):
@@ -33,12 +31,6 @@ def pytest_generate_tests(metafunc):
 
 
 @unittest.skipIf(SKIP_SMOKE, "smoke test is disabled by config")
-def test_smoke_main():
-    at = AppTest.from_file(APP_PATH, default_timeout=100).run()
-    assert not at.exception
-
-
-@unittest.skipIf(SKIP_SMOKE, "smoke test is disabled by config")
-def test_smoke_pages(file_path):
+def test_smoke_page(file_path):
     at = AppTest.from_file(file_path, default_timeout=100).run()
     assert not at.exception


### PR DESCRIPTION
Before 
```
collected 2 items                                                                          

st_smoke_test.py::test_smoke_main PASSED                                             [ 50%]
st_smoke_test.py::test_smoke_pages PASSED                                            [100%]

==================================== 2 passed in 1.10s =====================================
```

After
```
collected 3 items                                                                          

st_smoke_test.py::test_smoke_page[streamlit_app.py] PASSED                           [ 33%]
st_smoke_test.py::test_smoke_page[p1.py] PASSED                                      [ 66%]
st_smoke_test.py::test_smoke_page[p2.py] PASSED                                      [100%]

==================================== 3 passed in 0.94s =====================================
```