### PR TITLE
Clean up metadata to be clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # streamlit-app-action
 
-Github Action for basic validating Streamlit app. This action will:
+Github Action providing simple workflows for validating a Streamlit app. This action will:
 
 - Run `pytest` for any tests, including [Streamlit AppTests](https://docs.streamlit.io/library/api-reference/app-testing),
   that are part of your repo.

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Streamlit App Actions'
-description: 'Simple workflows for validating a Streamlit app'
+name: 'Streamlit App Action'
+description: 'Validate a Streamlit app with smoke tests and linting'
 branding:
   icon: 'book'
   color: 'blue'


### PR DESCRIPTION
- Use singular "action" name to match the repo
- Describe what the action does in a verb form, similar to other popular examples on https://github.com/marketplace?type=actions
- Update README description to match